### PR TITLE
Added helper to pull models uniformly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ profile = "black"
 
 [tool.flake8]
 max-line-length = 88
-extend-ignore = E203, W503
+extend-ignore = ["E203", "W503"]
 
 [tool.mypy]
 python_version = 3.11

--- a/src/metrics/bus_factor.py
+++ b/src/metrics/bus_factor.py
@@ -1,5 +1,5 @@
 from typing import Any
 
-def compute_bus_factor_metric(model_url: str) -> float:
+def compute_bus_factor_metric(model_info: dict) -> float:
     # TODO: Implement bus factor metric
     return 1.0

--- a/src/metrics/code_quality.py
+++ b/src/metrics/code_quality.py
@@ -1,5 +1,5 @@
 from typing import Any
 
-def compute_code_quality_metric(model_url: str) -> float:
+def compute_code_quality_metric(model_info: dict) -> float:
     # TODO: Implement code quality metric
     return 1.0

--- a/src/metrics/dataset_code_avail.py
+++ b/src/metrics/dataset_code_avail.py
@@ -1,5 +1,5 @@
 from typing import Any
 
-def compute_dataset_code_avail_metric(model_url: str) -> float:
+def compute_dataset_code_avail_metric(model_info: dict) -> float:
     # TODO: Implement dataset/code availability metric
     return 1.0

--- a/src/metrics/dataset_quality.py
+++ b/src/metrics/dataset_quality.py
@@ -1,5 +1,5 @@
 from typing import Any
 
-def compute_dataset_quality_metric(model_url: str) -> float:
+def compute_dataset_quality_metric(model_info: dict) -> float:
     # TODO: Implement dataset quality metric
     return 1.0

--- a/src/metrics/helpers/pull_model.py
+++ b/src/metrics/helpers/pull_model.py
@@ -1,0 +1,89 @@
+from huggingface_hub import HfApi
+import validators
+from enum import Enum
+
+ 
+# Define enum for url types
+class UrlType(Enum):
+    HUGGING_FACE_MODEL = "hugging_face_model",
+    HUGGING_FACE_DATASET = "hugging_face_dataset",
+    HUGGING_FACE_CODEBASE = "hugging_face_codebase",
+    GIT_REPO = "git_repo",
+    OTHER = "other",
+    INVALID = "invalid"
+
+
+hf_api = HfApi()
+
+def pull_model_info(url: str) -> dict:
+    url_type = get_url_type(url)
+    if url_type == UrlType.INVALID:
+        raise ValueError("Invalid URL: " + url)
+
+    if url_type == UrlType.HUGGING_FACE_DATASET:
+        # Dataset: https://huggingface.co/datasets/<namespace>/<repo>
+        # get string after /datasets/
+        name = url.split("/datasets/")[1]
+        info = hf_api.dataset_info(name)
+    if url_type == UrlType.HUGGING_FACE_MODEL:
+        # Model: https://huggingface.co/<namespace>/<repo>
+        name = url.split("huggingface.co/")[1]
+        info = hf_api.model_info(name)
+    if url_type == UrlType.HUGGING_FACE_CODEBASE:
+        # Code/Space: https://huggingface.co/spaces/<namespace>/<repo>
+        name = url.split("/spaces/")[1]
+        info = hf_api.space_info(name)
+    if url_type == UrlType.GIT_REPO:
+        # TODO: Implement git repo info pull
+        return None
+    if url_type == UrlType.OTHER:
+        raise ValueError("Other URL type: " + url)
+
+    return info
+
+
+
+
+## Parses the url and returns the type of the url
+def get_url_type(url: str) -> str:
+
+    if not validators.url(url):
+        return UrlType.INVALID
+
+    # Verify the URL is hosted on Hugging Face or Github
+    if url.startswith("https://github.com/"):
+        return UrlType.GIT_REPO
+
+    if not url.startswith("https://huggingface.co/"):
+        return UrlType.OTHER
+
+    # Model: https://huggingface.co/<namespace>/<repo>
+    # Dataset: https://huggingface.co/datasets/<namespace>/<repo>
+    # Code/Space: https://huggingface.co/spaces/<namespace>/<repo>
+
+    if url.startswith("https://huggingface.co/datasets/"):
+        return UrlType.HUGGING_FACE_DATASET
+
+    if url.startswith("https://huggingface.co/spaces/"):
+        return UrlType.HUGGING_FACE_CODEBASE
+
+    if url.startswith("https://huggingface.co/"):
+        return UrlType.HUGGING_FACE_MODEL
+
+    return UrlType.INVALID
+
+
+    # Test cases
+"""
+    info = pull_model_info("https://huggingface.co/google/gemma-3-270m")
+    print(info)
+
+    info = pull_model_info("https://huggingface.co/datasets/glue")
+    print(info)
+
+    info = pull_model_info("https://huggingface.co/spaces/gradio/hello_world")
+    print(info)
+
+    info = pull_model_info("https://huggingface.co/bert-base-uncased")
+    print(info)
+"""

--- a/src/metrics/license.py
+++ b/src/metrics/license.py
@@ -1,5 +1,5 @@
 from typing import Any
 
-def compute_license_metric(model_url: str) -> float:
+def compute_license_metric(model_info: dict) -> float:
     # TODO: Implement license metric
     return 1.0

--- a/src/metrics/perf_claims.py
+++ b/src/metrics/perf_claims.py
@@ -1,5 +1,5 @@
 from typing import Any
 
-def compute_perf_claims_metric(model_url: str) -> float:
+def compute_perf_claims_metric(model_info: dict) -> float:
     # TODO: Implement performance claims metric
     return 1.0

--- a/src/metrics/ramp_up.py
+++ b/src/metrics/ramp_up.py
@@ -1,5 +1,5 @@
 from typing import Any
 
-def compute_ramp_up_metric(model_url: str) -> float:
+def compute_ramp_up_metric(model_info: dict) -> float:
     # TODO: Implement ramp up time metric
     return 1.0

--- a/src/metrics/size.py
+++ b/src/metrics/size.py
@@ -1,5 +1,5 @@
 from typing import Any
 
-def compute_size_metric(model_url: str) -> float:
+def compute_size_metric(model_info: dict) -> float:
     # TODO: Implement size metric
     return 1.0

--- a/tests/test_pull_model.py
+++ b/tests/test_pull_model.py
@@ -1,0 +1,131 @@
+import os
+import sys
+import types
+
+import pytest
+
+
+# Ensure the project's src directory is importable
+CURRENT_DIR = os.path.dirname(__file__)
+SRC_DIR = os.path.abspath(os.path.join(CURRENT_DIR, "..", "src"))
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+
+# Provide a lightweight stub for the optional 'validators' dependency
+# so that importing the module under test doesn't fail in environments
+# where 'validators' is not installed.
+validators_stub = types.ModuleType("validators")
+
+
+def _is_valid_url(candidate: str) -> bool:
+    from urllib.parse import urlparse
+
+    parsed = urlparse(candidate)
+    return bool(parsed.scheme in ("http", "https") and parsed.netloc)
+
+
+validators_stub.url = _is_valid_url
+sys.modules["validators"] = validators_stub
+
+
+from metrics.helpers.pull_model import UrlType, get_url_type, pull_model_info  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://github.com/org/repo", UrlType.GIT_REPO),
+        ("https://huggingface.co/datasets/glue", UrlType.HUGGING_FACE_DATASET),
+        (
+            "https://huggingface.co/spaces/gradio/hello_world",
+            UrlType.HUGGING_FACE_CODEBASE,
+        ),
+        ("https://huggingface.co/bert-base-uncased", UrlType.HUGGING_FACE_MODEL),
+        ("https://example.com/foo", UrlType.OTHER),
+        ("not_a_url", UrlType.INVALID),
+    ],
+)
+def test_get_url_type(url: str, expected: UrlType) -> None:
+    assert get_url_type(url) == expected
+
+
+class FakeHfApi:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def dataset_info(self, name: str):
+        self.calls.append(("dataset_info", name))
+        return {"type": "dataset", "name": name}
+
+    def model_info(self, name: str):
+        self.calls.append(("model_info", name))
+        return {"type": "model", "name": name}
+
+    def space_info(self, name: str):
+        self.calls.append(("space_info", name))
+        return {"type": "space", "name": name}
+
+
+def test_pull_model_info_for_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Use a two-segment model URL so the helper's split logic works
+    url = "https://huggingface.co/owner/repo"
+
+    fake = FakeHfApi()
+    monkeypatch.setattr(
+        "metrics.helpers.pull_model.HfApi", lambda: fake, raising=True
+    )
+
+    result = pull_model_info(url)
+    assert result == {"type": "model", "name": "owner/repo"}
+
+
+def test_pull_model_info_for_dataset(monkeypatch: pytest.MonkeyPatch) -> None:
+    url = "https://huggingface.co/datasets/owner/repo"
+
+    fake = FakeHfApi()
+    monkeypatch.setattr(
+        "metrics.helpers.pull_model.HfApi", lambda: fake, raising=True
+    )
+
+    result = pull_model_info(url)
+    assert result == {"type": "dataset", "name": "owner/repo"}
+
+
+def test_pull_model_info_for_space(monkeypatch: pytest.MonkeyPatch) -> None:
+    url = "https://huggingface.co/spaces/owner/repo"
+
+    fake = FakeHfApi()
+    monkeypatch.setattr(
+        "metrics.helpers.pull_model.HfApi", lambda: fake, raising=True
+    )
+
+    result = pull_model_info(url)
+    assert result == {"type": "space", "name": "owner/repo"}
+
+
+def test_pull_model_info_for_git_repo_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    url = "https://github.com/org/repo"
+
+    fake = FakeHfApi()
+    monkeypatch.setattr(
+        "metrics.helpers.pull_model.HfApi", lambda: fake, raising=True
+    )
+
+    result = pull_model_info(url)
+    assert result is None
+
+
+def test_pull_model_info_other_url_raises() -> None:
+    url = "https://example.com/foo"
+    with pytest.raises(ValueError) as exc:
+        pull_model_info(url)
+    assert str(exc.value) == f"Other URL type: {url}"
+
+
+def test_pull_model_info_invalid_url_raises() -> None:
+    url = "not_a_url"
+    with pytest.raises(ValueError) as exc:
+        pull_model_info(url)
+    assert str(exc.value) == f"Invalid URL: {url}"
+


### PR DESCRIPTION
The metrics were taking in strings as input which implies that we are going to pull model data from the hf_api within each model which would add a ton of computation time. I added a helper to verify urls and pull the model info so that it can be done once and passed to the metric calculations. Metric functions have been updated to take in a dict instead