### PR TITLE
Code cleanup and added test coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import logging
+import pytest
+
+
+def _reset_logging_state():
+    for h in list(logging.root.handlers):
+        try:
+            h.flush()
+        except Exception:
+            pass
+        logging.root.removeHandler(h)
+    logging.root.setLevel(logging.NOTSET)
+
+
+@pytest.fixture(autouse=True)
+def isolate_logging():
+    _reset_logging_state()
+    yield
+    _reset_logging_state()

--- a/tests/test_code_quality.py
+++ b/tests/test_code_quality.py
@@ -1,0 +1,14 @@
+from src.metrics.code_quality import compute_code_quality_metric
+
+
+def test_code_quality_default_returns_one():
+    # Current implementation always returns 1.0
+    result = compute_code_quality_metric({})
+    assert result == 1.0
+
+
+def test_code_quality_ignores_input_fields():
+    # Ensure extra fields do not change the constant score
+    dummy = {"files": ["a.py"], "issues": 42}
+    result = compute_code_quality_metric(dummy)
+    assert result == 1.0

--- a/tests/test_dataset_code_avail.py
+++ b/tests/test_dataset_code_avail.py
@@ -13,7 +13,7 @@ class MockModelInfo:
         self.cardData = cardData if cardData is not None else {}
         self.siblings = siblings if siblings is not None else []
 
-@patch("src.dataset_code_avail._fetch_readme_content")
+@patch("src.metrics.dataset_code_avail._fetch_readme_content")
 def test_both_dataset_and_code_exist(mock_fetch):
     """Score should be 1.0 if dataset is in cardData and .py file exists."""
     mock_fetch.return_value = "Some readme content."
@@ -25,7 +25,7 @@ def test_both_dataset_and_code_exist(mock_fetch):
     score = compute_dataset_code_avail_metric(model_info)
     assert score == 1.0
 
-@patch("src.dataset_code_avail._fetch_readme_content")
+@patch("src.metrics.dataset_code_avail._fetch_readme_content")
 def test_dataset_from_readme_and_code_from_ipynb(mock_fetch):
     """Score should be 1.0 if dataset is in README and .ipynb file exists."""
     mock_fetch.return_value = "This model was trained on the xyz dataset."
@@ -36,7 +36,7 @@ def test_dataset_from_readme_and_code_from_ipynb(mock_fetch):
     score = compute_dataset_code_avail_metric(model_info)
     assert score == 1.0
 
-@patch("src.dataset_code_avail._fetch_readme_content")
+@patch("src.metrics.dataset_code_avail._fetch_readme_content")
 def test_only_dataset_available(mock_fetch):
     """Score should be 0.5 if only dataset is mentioned in cardData."""
     mock_fetch.return_value = "Some readme content."
@@ -47,7 +47,7 @@ def test_only_dataset_available(mock_fetch):
     score = compute_dataset_code_avail_metric(model_info)
     assert score == 0.5
 
-@patch("src.dataset_code_avail._fetch_readme_content")
+@patch("src.metrics.dataset_code_avail._fetch_readme_content")
 def test_only_code_available(mock_fetch):
     """Score should be 0.5 if only a notebook is present."""
     mock_fetch.return_value = "Some readme content."
@@ -58,7 +58,7 @@ def test_only_code_available(mock_fetch):
     score = compute_dataset_code_avail_metric(model_info)
     assert score == 0.5
 
-@patch("src.dataset_code_avail._fetch_readme_content")
+@patch("src.metrics.dataset_code_avail._fetch_readme_content")
 def test_neither_available(mock_fetch):
     """Score should be 0.0 if neither dataset nor code is found."""
     mock_fetch.return_value = "This is a model."

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -27,7 +27,7 @@ def test_license_from_card_data(license_id, expected_score):
     score = compute_license_metric(model_info)
     assert score == expected_score
 
-@patch("src.license._fetch_readme_content")
+@patch("src.metrics.license._fetch_readme_content")
 def test_license_from_readme_compatible(mock_fetch):
     """Tests finding a compatible license in the README."""
     mock_fetch.return_value = "## License\nThis model is licensed under the Apache 2.0 license."
@@ -35,7 +35,7 @@ def test_license_from_readme_compatible(mock_fetch):
     score = compute_license_metric(model_info)
     assert score == 1.0
 
-@patch("src.license._fetch_readme_content")
+@patch("src.metrics.license._fetch_readme_content")
 def test_license_from_readme_incompatible(mock_fetch):
     """Tests finding an incompatible license in the README."""
     mock_fetch.return_value = "## License\nThis is AGPL-3.0."
@@ -43,7 +43,7 @@ def test_license_from_readme_incompatible(mock_fetch):
     score = compute_license_metric(model_info)
     assert score == 0.0
 
-@patch("src.license._fetch_readme_content")
+@patch("src.metrics.license._fetch_readme_content")
 def test_license_unclear_from_readme(mock_fetch):
     """Tests when the README has no license section."""
     mock_fetch.return_value = "This is a model."
@@ -54,7 +54,7 @@ def test_license_unclear_from_readme(mock_fetch):
 def test_license_no_info():
     """Tests when there is no cardData and the README can't be fetched."""
     # The mock will default to returning an empty string, simulating a failed fetch
-    with patch("src.license._fetch_readme_content", return_value=""):
+    with patch("src.metrics.license._fetch_readme_content", return_value=""):
         model_info = MockModelInfo("mock/repo")
         score = compute_license_metric(model_info)
         assert score == 0.5

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,84 @@
+import logging
+import os
+import tempfile
+from importlib import reload
+
+import pytest
+
+import src.logging_config as logging_config
+
+
+def _reset_logging():
+    # Remove all handlers so basicConfig can reconfigure
+    for h in list(logging.root.handlers):
+        logging.root.removeHandler(h)
+    logging.root.setLevel(logging.NOTSET)
+
+
+def test_logging_level_critical_when_level_0(monkeypatch):
+    _reset_logging()
+    fd, log_path = tempfile.mkstemp(prefix="crit_", suffix=".log")
+    os.close(fd)
+    monkeypatch.setenv("LOG_FILE", log_path)
+    monkeypatch.setenv("LOG_LEVEL", "0")
+    reload(logging_config)
+    logging_config.setup_logging()
+    try:
+        assert logging.getLogger().level == logging.CRITICAL
+    finally:
+        for h in list(logging.root.handlers):
+            h.close()
+        os.remove(log_path)
+
+
+def test_logging_level_info_when_level_1(monkeypatch):
+    _reset_logging()
+    fd, log_path = tempfile.mkstemp(prefix="info_", suffix=".log")
+    os.close(fd)
+    monkeypatch.setenv("LOG_FILE", log_path)
+    monkeypatch.setenv("LOG_LEVEL", "1")
+    reload(logging_config)
+    logging_config.setup_logging()
+    try:
+        assert logging.getLogger().level == logging.INFO
+    finally:
+        for h in list(logging.root.handlers):
+            h.close()
+        os.remove(log_path)
+
+
+def test_logging_level_debug_when_level_other(monkeypatch):
+    _reset_logging()
+    fd, log_path = tempfile.mkstemp(prefix="debug_", suffix=".log")
+    os.close(fd)
+    monkeypatch.setenv("LOG_FILE", log_path)
+    monkeypatch.setenv("LOG_LEVEL", "2")
+    reload(logging_config)
+    logging_config.setup_logging()
+    try:
+        assert logging.getLogger().level == logging.DEBUG
+    finally:
+        for h in list(logging.root.handlers):
+            h.close()
+        os.remove(log_path)
+
+
+def test_logging_writes_to_file(monkeypatch):
+    _reset_logging()
+    fd, log_path = tempfile.mkstemp(prefix="write_", suffix=".log")
+    os.close(fd)
+    monkeypatch.setenv("LOG_FILE", log_path)
+    monkeypatch.setenv("LOG_LEVEL", "2")
+    reload(logging_config)
+    logging_config.setup_logging()
+    logging.info("Hello world")
+    for h in list(logging.root.handlers):
+        h.flush()
+    with open(log_path, "r", encoding="utf-8") as f:
+        contents = f.read()
+    try:
+        assert "Hello world" in contents
+    finally:
+        for h in list(logging.root.handlers):
+            h.close()
+        os.remove(log_path)

--- a/tests/test_net_score.py
+++ b/tests/test_net_score.py
@@ -1,0 +1,83 @@
+import math
+from src.net_score import calculate_net_score
+
+
+def test_net_score_all_max_scores():
+    metrics = {
+        "size_score": {"cpu": 1.0, "gpu": 1.0},
+        "ramp_up_time": 1.0,
+        "bus_factor": 1.0,
+        "dataset_and_code_score": 1.0,
+        "dataset_quality": 1.0,
+        "code_quality": 1.0,
+        "performance_claims": 1.0,
+        "license": 1.0,
+    }
+    score, latency = calculate_net_score(metrics)
+    # Weighted sum: 0.1 + (6 * 0.15) = 0.1 + 0.9 = 1.0 then * license(1)=1
+    assert score == 1.0
+    assert latency >= 0
+
+
+def test_net_score_license_zero_nullifies():
+    metrics = {
+        "size_score": {"cpu": 1.0},
+        "ramp_up_time": 1.0,
+        "bus_factor": 1.0,
+        "dataset_and_code_score": 1.0,
+        "dataset_quality": 1.0,
+        "code_quality": 1.0,
+        "performance_claims": 1.0,
+        "license": 0.0,
+    }
+    score, _ = calculate_net_score(metrics)
+    assert score == 0.0
+
+
+def test_net_score_missing_size_treated_as_zero():
+    metrics = {
+        # size_score missing
+        "ramp_up_time": 1.0,
+        "bus_factor": 1.0,
+        "dataset_and_code_score": 1.0,
+        "dataset_quality": 1.0,
+        "code_quality": 1.0,
+        "performance_claims": 1.0,
+        "license": 1.0,
+    }
+    score, _ = calculate_net_score(metrics)
+    # Weighted sum without size contributes only other metrics: 6*0.15 = 0.9
+    assert math.isclose(score, 0.9, rel_tol=1e-4)
+
+
+def test_net_score_size_average():
+    metrics = {
+        "size_score": {"cpu": 0.0, "gpu": 1.0},  # average 0.5 -> weighted 0.05
+        "ramp_up_time": 0.5,  # 0.075
+        "bus_factor": 0.5,    # 0.075
+        "dataset_and_code_score": 1.0,  # 0.15
+        "dataset_quality": 0.0,  # 0.0
+        "code_quality": 1.0,  # 0.15
+        "performance_claims": 0.5,  # 0.075
+        "license": 1.0,
+    }
+    # Expected sum = 0.05 + 0.075 + 0.075 + 0.15 + 0 + 0.15 + 0.075 = 0.575
+    score, _ = calculate_net_score(metrics)
+    assert math.isclose(score, 0.575, rel_tol=1e-4)
+
+
+def test_net_score_clamped_at_one():
+    metrics = {
+        "size_score": {"cpu": 1.0},
+        "ramp_up_time": 1.2,  # >1 should still just count as 1.2*0.15 in raw but final clamp after license
+        "bus_factor": 1.2,
+        "dataset_and_code_score": 1.2,
+        "dataset_quality": 1.2,
+        "code_quality": 1.2,
+        "performance_claims": 1.2,
+        "license": 2.0,  # exaggerate license to ensure overshoot
+    }
+    score, _ = calculate_net_score(metrics)
+    # Even if overweight, final result must be <=1
+    assert 0.0 <= score <= 1.0
+    assert score == 1.0

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,73 @@
+import json
+from unittest.mock import patch
+
+from src.orchestrator import calculate_all_metrics
+
+
+class DummyModelInfo:
+    def __init__(self, repo_id: str):
+        self.id = repo_id
+
+
+def test_orchestrator_smoke(monkeypatch):
+    dummy = DummyModelInfo("org/model")
+
+    # Provide deterministic fake metric outputs (patch inside orchestrator namespace because of direct imports)
+    monkeypatch.setattr("src.orchestrator.compute_ramp_up_metric", lambda m: 0.5)
+    monkeypatch.setattr("src.orchestrator.compute_bus_factor_metric", lambda m: 0.4)
+    monkeypatch.setattr("src.orchestrator.compute_license_metric", lambda m: 1.0)
+    monkeypatch.setattr(
+        "src.orchestrator.compute_size_metric",
+        lambda m: {"raspberry_pi": 0.2, "jetson_nano": 0.4, "desktop_pc": 0.8, "aws_server": 1.0},
+    )
+    monkeypatch.setattr("src.orchestrator.compute_dataset_code_avail_metric", lambda m: 0.6)
+    monkeypatch.setattr("src.orchestrator.compute_dataset_quality_metric", lambda m: 0.7)
+    monkeypatch.setattr("src.orchestrator.compute_code_quality_metric", lambda m: 0.9)
+    monkeypatch.setattr("src.orchestrator.compute_perf_claims_metric", lambda m: 0.3)
+
+    # Patch net score separately to isolate orchestrator flow OR let it compute
+    # We'll let it compute naturally; net score uses these values.
+
+    # Prevent README/network access in metrics that inspect repo files
+    monkeypatch.setattr("src.metrics.ramp_up.HfFileSystem", lambda: type("FS", (), {"ls": lambda self, repo_id, detail=False: [f"{repo_id}/README.md"]})())
+    monkeypatch.setattr("src.metrics.ramp_up.hf_hub_download", lambda **kwargs: __file__)
+    monkeypatch.setattr("src.metrics.license.HfFileSystem", lambda: type("FS", (), {"ls": lambda self, repo_id, detail=False: [f"{repo_id}/README.md"]})())
+    monkeypatch.setattr("src.metrics.license.hf_hub_download", lambda **kwargs: __file__)
+    monkeypatch.setattr("src.metrics.dataset_code_avail.HfFileSystem", lambda: type("FS", (), {"ls": lambda self, repo_id, detail=False: [f"{repo_id}/README.md"]})())
+    monkeypatch.setattr("src.metrics.dataset_code_avail.hf_hub_download", lambda **kwargs: __file__)
+
+    output_json = calculate_all_metrics(dummy, "https://huggingface.co/org/model")
+    data = json.loads(output_json)
+
+    # Core keys present
+    for key in [
+        "name",
+        "category",
+        "net_score",
+        "ramp_up_time",
+        "bus_factor",
+        "license",
+        "size_score",
+        "dataset_and_code_score",
+        "dataset_quality",
+        "code_quality",
+        "performance_claims",
+    ]:
+        assert key in data
+
+    assert data["name"] == "org/model"
+    assert data["category"] == "MODEL"
+
+    # Spot check a couple of values
+    assert data["ramp_up_time"] == 0.5
+    assert data["size_score"]["raspberry_pi"] == 0.2
+
+    # Net score should be between 0 and 1
+    assert 0.0 <= data["net_score"] <= 1.0
+
+    # Latency keys exist and are integers
+    latency_keys = [k for k in data.keys() if k.endswith("_latency")]
+    assert latency_keys
+    for lk in latency_keys:
+        assert isinstance(data[lk], int)
+        assert data[lk] >= 0

--- a/tests/test_perf_claims.py
+++ b/tests/test_perf_claims.py
@@ -1,0 +1,10 @@
+from src.metrics.perf_claims import compute_perf_claims_metric
+
+
+def test_perf_claims_returns_one_for_empty():
+    assert compute_perf_claims_metric({}) == 1.0
+
+
+def test_perf_claims_ignores_input_fields():
+    dummy = {"benchmarks": ["glue", "squad"], "accuracy": 0.9}
+    assert compute_perf_claims_metric(dummy) == 1.0

--- a/tests/test_ramp_up.py
+++ b/tests/test_ramp_up.py
@@ -12,7 +12,7 @@ def mock_model_info():
     """Provides a mock model_info object."""
     return MockModelInfo("mock/repo")
 
-@patch("src.ramp_up.hf_hub_download")
+@patch("src.metrics.ramp_up.hf_hub_download")
 @patch("builtins.open", new_callable=mock_open)
 def test_ramp_up_ideal_word_count(mock_file, mock_download, mock_model_info):
     """
@@ -25,12 +25,12 @@ def test_ramp_up_ideal_word_count(mock_file, mock_download, mock_model_info):
     mock_download.return_value = "dummy/path/README.md"
 
     # The mock for fs.ls() needs to return a list containing a readme
-    with patch("src.ramp_up.HfFileSystem") as mock_fs:
+    with patch("src.metrics.ramp_up.HfFileSystem") as mock_fs:
         mock_fs.return_value.ls.return_value = ["mock/repo/README.md"]
         score = compute_ramp_up_metric(mock_model_info)
         assert score == pytest.approx(1.0)
 
-@patch("src.ramp_up.hf_hub_download")
+@patch("src.metrics.ramp_up.hf_hub_download")
 @patch("builtins.open", new_callable=mock_open)
 def test_ramp_up_very_short_readme(mock_file, mock_download, mock_model_info):
     """
@@ -41,12 +41,12 @@ def test_ramp_up_very_short_readme(mock_file, mock_download, mock_model_info):
     mock_file.return_value.read.return_value = short_readme
     mock_download.return_value = "dummy/path/README.md"
 
-    with patch("src.ramp_up.HfFileSystem") as mock_fs:
+    with patch("src.metrics.ramp_up.HfFileSystem") as mock_fs:
         mock_fs.return_value.ls.return_value = ["mock/repo/README.md"]
         score = compute_ramp_up_metric(mock_model_info)
         assert score < 0.2
 
-@patch("src.ramp_up.HfFileSystem")
+@patch("src.metrics.ramp_up.HfFileSystem")
 def test_ramp_up_no_readme(mock_fs, mock_model_info):
     """
     Tests the ramp-up score when no README file is found.


### PR DESCRIPTION
Refactored pull_model.py to use hf_api.py so we retain full functionality without duplicate code, fixed bad patch targets, added new tests: code quality, logging config, net score, orchestrator.py, performance claims.

What the New Tests Cover:
- Net score weighting, size averaging, license multiplier, clamping.
- Logging level mapping and file emission.
- Orchestrator end-to-end record assembly (patched deterministic metrics).
- Stub metrics (code_quality, perf_claims) to lock expected behavior (I think this will change when the metrics are developed).
- Performance claims metric placeholder behavior.
- Refactored URL/model/dataset/space resolution tests now cleaner.

We have 57% line coverage now.

Resolves #29